### PR TITLE
Move non-ensime specific functions to sbt-mode

### DIFF
--- a/sbt-mode.el
+++ b/sbt-mode.el
@@ -92,6 +92,31 @@ sbt:default-command, if no other command has yet been run)."
   (interactive)
   (sbt:command (sbt:get-previous-command)))
 
+(defun sbt-do-compile ()
+  "Compile all sources including tests."
+  (interactive)
+  (sbt:command "test:compile"))
+
+(defun sbt-do-run ()
+  "Execute the sbt `run' command for the project."
+  (interactive)
+  (sbt:command "run"))
+
+(defun sbt-do-test ()
+  "Run all the tests."
+  (interactive)
+  (sbt-command "test"))
+
+(defun sbt-do-clean ()
+  "Execute the sbt `clean' command for the project."
+  (interactive)
+  (sbt:command "clean"))
+
+(defun sbt-do-package ()
+  "Build a jar file of the project."
+  (interactive)
+  (sbt:command "package"))
+
 (defun sbt-completion-at-point ()
   "Complete the command at point. Works both in sbt shell and
 scala console."


### PR DESCRIPTION
Reopening https://github.com/ensime/emacs-sbt-mode/pull/151. I've been using a patched mode with this, and it would be nice to get it upstream.  All credit to @yyadavalli.